### PR TITLE
Resolve dependencies when installing from pypi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,33 @@
-*.pyc
 MANIFEST
-docs/build
+
+*.py[cod]
+
+# C extensions
+*.so
+
+# Packages
+*.egg
+*.egg-info
 dist
 build
+eggs
+parts
+bin
+var
+sdist
+develop-eggs
+.installed.cfg
+lib
+lib64
+__pycache__
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+.coverage
+.tox
+nosetests.xml
+
+# Docs
+docs/_build/

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,16 @@
 #!/usr/bin/env python
 
 import re
-from distutils.core import setup
+from setuptools import setup
 
 version = re.search(
     '^__version__\s*=\s*"(.*)"',
     open('wbdata/__init__.py').read(),
     re.M
     ).group(1)
+
+with open('requirements.txt') as f:
+    required = f.read().splitlines()
 
 setup(
     name='wbdata',
@@ -17,7 +20,7 @@ setup(
     packages=["wbdata"],
     url="https://github.com/oliversherouse/wbdata",
     description="A library to access World Bank data",
-    requires=["decorator"],
+    install_requires=required,
     long_description=open('README.rst').read(),
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
I just installed wbdata via pip and the required `decorator` package was not automatically installed. I changed the setup script to correctly resolve and install all dependencies listed in requirements.txt

I also added .egg-info and some more patterns to .gitignore, that you usually don't want in a Python project, these patterns come from https://github.com/github/gitignore/blob/master/Python.gitignore
