### PR TITLE
handle EOF error when reading corrupted pickle file on load

### DIFF
--- a/wbdata/fetcher.py
+++ b/wbdata/fetcher.py
@@ -80,6 +80,8 @@ class Cache(object):
                                             errors="replace")
                     except TypeError:
                         cache = pickle.load(cachefile)
+                    except EOFError: # possible if cachefile exists but corrupted
+                        cache = {}
             except IOError:
                 cache = {}
             self.__cache = cache


### PR DESCRIPTION
If user is trying to load pickle file that has been corrupted on read, hits EOFError because file exists but pickle load is unsuccessful